### PR TITLE
spi_nand_flash: don't break the loop on erase fail

### DIFF
--- a/src/spi_nand_flash.c
+++ b/src/spi_nand_flash.c
@@ -2915,7 +2915,6 @@ static SPI_NAND_FLASH_RTN_T spi_nand_erase_internal( u32 addr, u32 len )
 			{
 				_SPI_NAND_PRINTF("spi_nand_erase_internal : Erase Fail at addr = 0x%x, len = 0x%x, block_idx = 0x%x\n", addr, len, block_index);
 				rtn_status = SPI_NAND_FLASH_RTN_ERASE_FAIL;
-				break;
 			}
 
 			/* 2.7 Erase next block if needed */


### PR DESCRIPTION
NAND flash memories are allowed to contain some bad blocks, which fail
to write or fail to erase. Currently, chip erase operation breaks on
first failed block, leaving the rest of memory untouched. So, to do full
chip erase with failed blocks, manual fiddling with addresses is needed.

To avoid that, don't break the loop on erase fail, but keep the final
error status.