### PR TITLE
spi_nor_flash: print size in KB when size is less than 1MB

### DIFF
--- a/src/spi_nor_flash.c
+++ b/src/spi_nor_flash.c
@@ -514,7 +514,12 @@ struct chip_info *chip_prob(void)
 		info = &chips_data[i];
 		if (info->id == buf[0]) {
 			if ((info->jedec_id == jedec) || ((info->jedec_id & 0xffff0000) == jedec_strip)) {
-				printf("Detected SPI NOR Flash:\e[93m %s\e[0m, Flash Size:\e[93m %ld \e[0mMB\n", info->name, (info->sector_size * info->n_sectors) >> 20);
+				long int size = (info->sector_size * info->n_sectors);
+				if ((size >> 10) >= 1024) {
+					printf("Detected SPI NOR Flash:\e[93m %s\e[0m, Flash Size:\e[93m %ld \e[0mMB\n", info->name, size >> 20);
+				} else {
+					printf("Detected SPI NOR Flash:\e[93m %s\e[0m, Flash Size:\e[93m %ld \e[0mKB\n", info->name, size >> 10);
+				}
 				return info;
 			}
 


### PR DESCRIPTION
before: `Detected SPI NOR Flash: MX25L4005A, Flash Size: 0 MB`

after: `Detected SPI NOR Flash: MX25L4005A, Flash Size: 512 KB`